### PR TITLE
Display device info on default tool command

### DIFF
--- a/Harp.Toolkit/Harp.Toolkit.csproj
+++ b/Harp.Toolkit/Harp.Toolkit.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Harp" Version="3.5.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>

--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -1,0 +1,36 @@
+﻿using System.CommandLine;
+using Bonsai.Harp;
+
+namespace Harp.Toolkit;
+
+internal class Program
+{
+    static async Task Main(string[] args)
+    {
+        var portName = new Option<string>(
+            name: "--port",
+            description: "Specifies the name of the serial port used to communicate with the device."
+        ) { IsRequired = true };
+        portName.ArgumentHelpName = nameof(portName);
+
+        var rootCommand = new RootCommand("Tool for inspecting, updating and interfacing with Harp devices.");
+        rootCommand.AddOption(portName);
+        rootCommand.SetHandler(async (portName) =>
+        {
+            using var device = new AsyncDevice(portName);
+            var whoAmI = await device.ReadWhoAmIAsync();
+            var hardwareVersion = await device.ReadHardwareVersionAsync();
+            var firmwareVersion = await device.ReadFirmwareVersionAsync();
+            var timestamp = await device.ReadTimestampSecondsAsync();
+            var deviceName = await device.ReadDeviceNameAsync();
+            Console.WriteLine($"Harp device found in {portName}");
+            Console.WriteLine($"DeviceName: {deviceName}");
+            Console.WriteLine($"WhoAmI: {whoAmI}");
+            Console.WriteLine($"Hw: {hardwareVersion.Major}.{hardwareVersion.Minor}");
+            Console.WriteLine($"Fw: {firmwareVersion.Major}.{firmwareVersion.Minor}");
+            Console.WriteLine($"Timestamp (s): {timestamp}");
+            Console.WriteLine();
+        }, portName);
+        await rootCommand.InvokeAsync(args);
+    }
+}


### PR DESCRIPTION
The simplest use for the tool is to inspect connected devices on a specified serial port. Currently this mimics the behavior of the generic `Device` node and displays basic device info including the device WhoAmI identifier, and firmware and hardware versions. The output is sent to standard out for logging. A required port name option is introduced which can be reused by other subcommands.

Example usage:
```
dotnet harp.toolkit --port COM4
```