### PR TITLE
Add command for listing serial port names

### DIFF
--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.IO.Ports;
 using Bonsai.Harp;
 
 namespace Harp.Toolkit;
@@ -13,8 +14,16 @@ internal class Program
         ) { IsRequired = true };
         portName.ArgumentHelpName = nameof(portName);
 
+        var listCommand = new Command("list", description: "");
+        listCommand.SetHandler(() =>
+        {
+            var portNames = SerialPort.GetPortNames();
+            Console.WriteLine($"PortNames: [{string.Join(", ", portNames)}]");
+        });
+
         var rootCommand = new RootCommand("Tool for inspecting, updating and interfacing with Harp devices.");
         rootCommand.AddOption(portName);
+        rootCommand.AddCommand(listCommand);
         rootCommand.SetHandler(async (portName) =>
         {
             using var device = new AsyncDevice(portName);


### PR DESCRIPTION
To assist finding available devices in the local computer it is very useful to list the configured serial ports in the system. Here we introduce the `list` sub-command which will simply scan the system for all available serial port names and print them in a comma-separated list to standard out.

Example usage:
```
dotnet harp.toolkit list
```