### PR TITLE
Add command for updating device firmware

### DIFF
--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -20,6 +20,11 @@ internal class Program
         ) { IsRequired = true };
         firmwarePath.ArgumentHelpName = nameof(firmwarePath);
 
+        var forceUpdate = new Option<bool>(
+            name: "--force",
+            description: "Indicates whether to force a firmware update on the device regardless of compatibility."
+        );
+
         var listCommand = new Command("list", description: "");
         listCommand.SetHandler(() =>
         {
@@ -30,12 +35,13 @@ internal class Program
         var updateCommand = new Command("update", description: "");
         updateCommand.AddOption(portName);
         updateCommand.AddOption(firmwarePath);
-        updateCommand.SetHandler(async (portName, firmwarePath) =>
+        updateCommand.AddOption(forceUpdate);
+        updateCommand.SetHandler(async (portName, firmwarePath, forceUpdate) =>
         {
             var firmware = DeviceFirmware.FromFile(firmwarePath.FullName);
             Console.WriteLine($"{firmware.Metadata}");
-            await Bootloader.UpdateFirmwareAsync(portName, firmware);
-        }, portName, firmwarePath);
+            await Bootloader.UpdateFirmwareAsync(portName, firmware, forceUpdate);
+        }, portName, firmwarePath, forceUpdate);
 
         var rootCommand = new RootCommand("Tool for inspecting, updating and interfacing with Harp devices.");
         rootCommand.AddOption(portName);

--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -40,7 +40,9 @@ internal class Program
         {
             var firmware = DeviceFirmware.FromFile(firmwarePath.FullName);
             Console.WriteLine($"{firmware.Metadata}");
-            await Bootloader.UpdateFirmwareAsync(portName, firmware, forceUpdate);
+            ProgressBar.Write(0);
+            var progress = new Progress<int>(ProgressBar.Update);
+            await Bootloader.UpdateFirmwareAsync(portName, firmware, forceUpdate, progress);
         }, portName, firmwarePath, forceUpdate);
 
         var rootCommand = new RootCommand("Tool for inspecting, updating and interfacing with Harp devices.");

--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -41,8 +41,12 @@ internal class Program
             var firmware = DeviceFirmware.FromFile(firmwarePath.FullName);
             Console.WriteLine($"{firmware.Metadata}");
             ProgressBar.Write(0);
-            var progress = new Progress<int>(ProgressBar.Update);
-            await Bootloader.UpdateFirmwareAsync(portName, firmware, forceUpdate, progress);
+            try
+            {
+                var progress = new Progress<int>(ProgressBar.Update);
+                await Bootloader.UpdateFirmwareAsync(portName, firmware, forceUpdate, progress);
+            }
+            finally { Console.WriteLine(); }
         }, portName, firmwarePath, forceUpdate);
 
         var rootCommand = new RootCommand("Tool for inspecting, updating and interfacing with Harp devices.");

--- a/Harp.Toolkit/ProgressBar.cs
+++ b/Harp.Toolkit/ProgressBar.cs
@@ -1,0 +1,22 @@
+﻿namespace Harp.Toolkit;
+
+internal static class ProgressBar
+{
+    public static void Update(int percent)
+    {
+        Console.CursorLeft = 0;
+        Write(percent);
+    }
+
+    public static void Write(int percent)
+    {
+        const int Length = 10;
+        Console.Write("[");
+        var p = percent / Length;
+        for (int i = 0; i < Length; i++)
+        {
+            Console.Write(i < p ? '■' : ' ');
+        }
+        Console.Write("] {0,3:##0}%", percent);
+    }
+}


### PR DESCRIPTION
To assist bulk updating of firmware in multiple devices we introduce here the `update` sub-command. It requires both a port name and the path to a binary firmware file in Intel HEX format. By default the firmware metadata is compared to the device identifier and hardware revisions to determine compatibility.

The optional `--force` flag can be used to flash the device with the specified firmware regardless of compatibility. 

Example usage:
```
dotnet harp.toolkit update --port COM4 --path .\TimestampGeneratorGen3-fw1.1-harp1.13-hw1.2-ass0.hex
```