### PR TITLE
Add support for specifying device response timeout

### DIFF
--- a/Harp.Toolkit/TaskExtensions.cs
+++ b/Harp.Toolkit/TaskExtensions.cs
@@ -1,0 +1,16 @@
+namespace Harp.Toolkit;
+
+static class TaskExtensions
+{
+    internal static async Task<T> WithTimeout<T>(this Task<T> task, int? millisecondsDelay)
+    {
+        if (!millisecondsDelay.HasValue)
+            return await task;
+
+        if (await Task.WhenAny(task, Task.Delay(millisecondsDelay.GetValueOrDefault())) == task)
+        {
+            return task.Result;
+        }
+        else throw new TimeoutException("There was a timeout while awaiting the device response.");
+    }
+}


### PR DESCRIPTION
While scanning for devices we may need to open a connection to serial ports of devices which may not implement the Harp protocol. Since we do not control those devices, we may not be able to exchange information with them, and therefore errors or even the complete absence of a response may ensue.

This PR addresses this by introducing a new `--timeout` option to the root command allowing to specify a maximum time in milliseconds to receive the first response from the device.