### PR TITLE
Add getting started guide and subcommand description strings

### DIFF
--- a/Harp.Toolkit/Program.cs
+++ b/Harp.Toolkit/Program.cs
@@ -30,14 +30,14 @@ internal class Program
             description: "Indicates whether to force a firmware update on the device regardless of compatibility."
         );
 
-        var listCommand = new Command("list", description: "");
+        var listCommand = new Command("list", description: "List all available system serial ports.");
         listCommand.SetHandler(() =>
         {
             var portNames = SerialPort.GetPortNames();
             Console.WriteLine($"PortNames: [{string.Join(", ", portNames)}]");
         });
 
-        var updateCommand = new Command("update", description: "");
+        var updateCommand = new Command("update", description: "Update the device firmware from a local HEX file.");
         updateCommand.AddOption(portName);
         updateCommand.AddOption(firmwarePath);
         updateCommand.AddOption(forceUpdate);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
-# harp-cli
-A tool for inspecting, updating and interfacing with Harp devices from the command-line
+# Harp Toolkit
+
+Tool for inspecting, updating and interfacing with Harp devices.
+
+## Getting Started
+
+1. Navigate to the [Harp.Toolkit NuGet tool package](https://www.nuget.org/packages/Harp.Toolkit/)
+2. Click `.NET CLI (Local)` and copy the two suggested commands. E.g.:
+
+    ```cmd
+    dotnet new tool-manifest # if you are setting up this repo
+    dotnet tool install --local Harp.Toolkit
+    ```
+
+3. To view the tool help reference documentation, run:
+
+    ```cmd
+    dotnet harp.toolkit --help
+    ```
+
+4. To list all available system serial ports:
+
+    ```cmd
+    dotnet harp.toolkit list
+    ```
+
+5. To display info about a device connected to a specific serial port:
+
+    ```cmd
+    dotnet harp.toolkit --port COM4
+    ```
+
+6. To update the device firmware from a local HEX file:
+
+    ```cmd
+    dotnet harp.toolkit update --port COM4 --path .\TimestampGeneratorGen3-fw1.1-harp1.13-hw1.2-ass0.hex
+    ```
+
+7. To restore the tool at any point, run:
+
+    ```cmd
+    dotnet tool restore
+    ```


### PR DESCRIPTION
This PR compiles all tool usage examples into the README file and fleshes out the missing subcommand description strings.