### PR TITLE
Refactor repository layout to allow multiple projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
-.vs
-.vscode
-bin
-obj
+.vs/
+.vscode/
+/artifacts/
 *.user
 *.suo
 *.hex

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,20 +3,15 @@
   <PropertyGroup>
     <Authors>harp-tech</Authors>
     <PackageIcon>icon.png</PackageIcon>
-    <Description>A tool for inspecting, updating and interfacing with Harp devices from the command-line.</Description>
-    <ToolCommandName>harp.toolkit</ToolCommandName>
-    <PackageTags>Harp Toolkit Device Firmware</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Copyright>Copyright © harp-tech and Contributors 2024</Copyright>
+    <Copyright>Copyright © harp-tech and Contributors</Copyright>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <PackageOutputPath>..\bin\$(Configuration)</PackageOutputPath>
-    <PackageProjectUrl>https://github.com/harp-tech/harp-cli</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/harp-tech/harp-cli.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/harp-tech/toolkit</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
     <VersionSuffix></VersionSuffix>
-    <RepositoryType>git</RepositoryType>
-    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/Harp.Toolkit/Harp.Toolkit.csproj
+++ b/Harp.Toolkit/Harp.Toolkit.csproj
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>harp.toolkit</ToolCommandName>
+    <Description>A tool for inspecting, updating and interfacing with Harp devices from the command-line.</Description>
+    <PackageTags>Harp Toolkit Device Firmware</PackageTags>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <VersionPrefix>0.1.0</VersionPrefix>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 harp-tech and Contributors
+Copyright (c) harp-tech and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Project specific properties have been removed from the common `Directory.Build.props` file and the artifacts layout was adopted to standardize packing of multiple project builds.