### PR TITLE
Add device project template into toolkit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <PackageProjectUrl>https://github.com/harp-tech/toolkit</PackageProjectUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <UseArtifactsOutput>true</UseArtifactsOutput>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/Harp.Templates/Harp.DeviceTemplate/.template.config/template.json
+++ b/Harp.Templates/Harp.DeviceTemplate/.template.config/template.json
@@ -1,0 +1,111 @@
+{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "harp-tech",
+    "classifications": [ "Harp", "Device" ],
+    "description": "A template for creating a new Harp device repository",
+    "identity": "Harp.DeviceTemplate",
+    "name": "Harp Device",
+    "tags": {
+        "type": "solution"
+    },
+    "sources": [
+        {
+            "modifiers": [
+                {
+                    "rename": {
+                        "template.editorconfig": ".editorconfig",
+                        "template.gitignore": ".gitignore"
+                    }
+                }
+            ]
+        }
+    ],
+    "symbols": {
+        "projectName": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "identity",
+            "fileRename": "DeviceTemplate"
+        },
+        "projectTitle": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "replaceDotsWithSpaces",
+            "replaces": "$title$"
+        },
+        "deviceName": {
+            "type": "derived",
+            "valueSource": "name",
+            "valueTransform": "valueAfterLastDot",
+            "replaces": "$devicename$"
+        },
+        "authors": {
+            "type": "parameter",
+            "defaultValue": "",
+            "replaces": "$registeredorganization$"
+        },
+        "year": {
+            "type": "generated",
+            "generator": "now",
+            "parameters": {
+                "format": "yyyy"
+            },
+            "replaces": "$year$"
+        },
+        "swguid1": {
+            "type": "generated",
+            "generator": "guid",
+            "replaces": "$swguid1$",
+            "parameters": {
+                "defaultFormat": "B"
+            }
+        },
+        "swguid2": {
+            "type": "generated",
+            "generator": "guid",
+            "replaces": "$swguid2$",
+            "parameters": {
+                "defaultFormat": "B"
+            }
+        },
+        "swguid3": {
+            "type": "generated",
+            "generator": "guid",
+            "replaces": "$swguid3$",
+            "parameters": {
+                "defaultFormat": "B"
+            }
+        },
+        "fwguid1": {
+            "type": "generated",
+            "generator": "guid",
+            "replaces": "$fwguid1$",
+            "parameters": {
+                "defaultFormat": "B"
+            }
+        },
+        "fwguid2": {
+            "type": "generated",
+            "generator": "guid",
+            "replaces": "$fwguid2$",
+            "parameters": {
+                "defaultFormat": "B"
+            }
+        }
+    },
+    "forms": {
+        "valueAfterLastDot": {
+            "identifier": "replace",
+            "pattern": "^.*\\.(?=[^\\.]+$)",
+            "replacement": ""
+        },
+        "replaceDotsWithSpaces": {
+            "identifier": "replace",
+            "pattern": "\\.",
+            "replacement": " "
+        }
+    },
+    "sourceName": "$projectname$",
+    "shortName": "harpdevice",
+    "preferNameDirectory": true
+}

--- a/Harp.Templates/Harp.DeviceTemplate/Firmware/DeviceTemplate.atsln
+++ b/Harp.Templates/Harp.DeviceTemplate/Firmware/DeviceTemplate.atsln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Atmel Studio Solution File, Format Version 11.00
+Project("$fwguid1$") = "$projectname$", "$projectname$\$projectname$.cproj", "$fwguid2$"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|AVR = Debug|AVR
+		Release|AVR = Release|AVR
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		$fwguid2$.Debug|AVR.ActiveCfg = Debug|AVR
+		$fwguid2$.Debug|AVR.Build.0 = Debug|AVR
+		$fwguid2$.Release|AVR.ActiveCfg = Release|AVR
+		$fwguid2$.Release|AVR.Build.0 = Release|AVR
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Harp.Templates/Harp.DeviceTemplate/Firmware/DeviceTemplate/DeviceTemplate.cproj
+++ b/Harp.Templates/Harp.DeviceTemplate/Firmware/DeviceTemplate/DeviceTemplate.cproj
@@ -1,0 +1,171 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectVersion>7.0</ProjectVersion>
+    <ToolchainName>com.Atmel.AVRGCC8.C</ToolchainName>
+    <ProjectGuid>$fwguid2$</ProjectGuid>
+    <avrdevice>ATxmega128A1U</avrdevice>
+    <avrdeviceseries>none</avrdeviceseries>
+    <OutputType>Executable</OutputType>
+    <Language>C</Language>
+    <OutputFileName>$(MSBuildProjectName)</OutputFileName>
+    <OutputFileExtension>.elf</OutputFileExtension>
+    <OutputDirectory>$(MSBuildProjectDirectory)\$(Configuration)</OutputDirectory>
+    <AssemblyName>$devicename$</AssemblyName>
+    <Name>$devicename$</Name>
+    <RootNamespace>$devicename$</RootNamespace>
+    <ToolchainFlavour>Native</ToolchainFlavour>
+    <KeepTimersRunning>true</KeepTimersRunning>
+    <OverrideVtor>false</OverrideVtor>
+    <CacheFlash>true</CacheFlash>
+    <ProgFlashFromRam>true</ProgFlashFromRam>
+    <RamSnippetAddress>0x20000000</RamSnippetAddress>
+    <UncachedRange />
+    <preserveEEPROM>true</preserveEEPROM>
+    <OverrideVtorValue>exception_table</OverrideVtorValue>
+    <BootSegment>2</BootSegment>
+    <eraseonlaunchrule>0</eraseonlaunchrule>
+    <AsfFrameworkConfig>
+      <framework-data>
+        <options />
+        <configurations />
+        <files />
+        <documentation help="" />
+        <offline-documentation help="" />
+        <dependencies>
+          <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.39.0" />
+        </dependencies>
+      </framework-data>
+    </AsfFrameworkConfig>
+    <avrtool>com.atmel.avrdbg.tool.atmelice</avrtool>
+    <avrtoolinterface>PDI</avrtoolinterface>
+    <com_atmel_avrdbg_tool_atmelice>
+      <ToolOptions>
+        <InterfaceProperties>
+          <PdiClock>4000000</PdiClock>
+        </InterfaceProperties>
+        <InterfaceName>PDI</InterfaceName>
+      </ToolOptions>
+      <ToolType>com.atmel.avrdbg.tool.atmelice</ToolType>
+      <ToolNumber>J42700022647</ToolNumber>
+      <ToolName>Atmel-ICE</ToolName>
+    </com_atmel_avrdbg_tool_atmelice>
+    <ResetRule>0</ResetRule>
+    <EraseKey />
+    <avrtoolserialnumber>J42700022647</avrtoolserialnumber>
+    <avrdeviceexpectedsignature>0x1E974C</avrdeviceexpectedsignature>
+    <avrtoolinterfaceclock>4000000</avrtoolinterfaceclock>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <ToolchainSettings>
+      <AvrGcc>
+  <avrgcc.common.Device>-mmcu=atxmega128a1u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega128a1u"</avrgcc.common.Device>
+  <avrgcc.common.optimization.RelaxBranches>True</avrgcc.common.optimization.RelaxBranches>
+  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>NDEBUG</Value>
+    </ListValues>
+  </avrgcc.compiler.symbols.DefSymbols>
+  <avrgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+    </ListValues>
+  </avrgcc.compiler.directories.IncludePaths>
+  <avrgcc.compiler.optimization.level>Optimize for size (-Os)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+  <avrgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </avrgcc.linker.libraries.Libraries>
+  <avrgcc.linker.libraries.LibrarySearchPaths>
+    <ListValues>
+    </ListValues>
+  </avrgcc.linker.libraries.LibrarySearchPaths>
+  <avrgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+    </ListValues>
+  </avrgcc.assembler.general.IncludePaths>
+</AvrGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <ToolchainSettings>
+      <AvrGcc>
+  <avrgcc.common.Device>-mmcu=atxmega128a1u -B "%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\gcc\dev\atxmega128a1u"</avrgcc.common.Device>
+  <avrgcc.common.optimization.RelaxBranches>True</avrgcc.common.optimization.RelaxBranches>
+  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>DEBUG</Value>
+    </ListValues>
+  </avrgcc.compiler.symbols.DefSymbols>
+  <avrgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+    </ListValues>
+  </avrgcc.compiler.directories.IncludePaths>
+  <avrgcc.compiler.optimization.level>Optimize most (-O3)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+  <avrgcc.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+      <Value>libATxmega128A1U-1.11.a</Value>
+    </ListValues>
+  </avrgcc.linker.libraries.Libraries>
+  <avrgcc.linker.libraries.LibrarySearchPaths>
+    <ListValues>
+      <Value>..</Value>
+    </ListValues>
+  </avrgcc.linker.libraries.LibrarySearchPaths>
+  <avrgcc.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\atmel\XMEGAA_DFP\1.1.68\include</Value>
+    </ListValues>
+  </avrgcc.assembler.general.IncludePaths>
+  <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
+</AvrGcc>
+    </ToolchainSettings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="app.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="app_funcs.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="app_ios_and_regs.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="interrupts.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="main.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="WS2812S.c">
+      <SubType>compile</SubType>
+    </Compile>
+  </ItemGroup>
+  <Import Project="$(AVRSTUDIO_EXE_PATH)\\Vs\\Compiler.targets" />
+</Project>

--- a/Harp.Templates/Harp.DeviceTemplate/Firmware/template.gitignore
+++ b/Harp.Templates/Harp.DeviceTemplate/Firmware/template.gitignore
@@ -1,0 +1,9 @@
+# Visual studio files
+.vs
+.suo
+.nuget
+bin
+obj
+Debug
+packages
+*.componentinfo.xml

--- a/Harp.Templates/Harp.DeviceTemplate/Generators/Generators.csproj
+++ b/Harp.Templates/Harp.DeviceTemplate/Generators/Generators.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>$projectname$</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DeviceMetadata>..\device.yml</DeviceMetadata>
+    <IOMetadata>..\ios.yml</IOMetadata>
+  </PropertyGroup>
+  <PropertyGroup>
+    <InterfacePath>..\Interface\$projectname$</InterfacePath>
+    <FirmwarePath>..\Firmware\$projectname$</FirmwarePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Harp.Generators" Version="0.4.0" GeneratePathProperty="true" />
+  </ItemGroup>
+  <Target Name="TextTransform" BeforeTargets="AfterBuild">
+    <PropertyGroup>
+      <InterfaceFlags>-p:MetadataPath=$(DeviceMetadata) -p:Namespace=$(RootNamespace) -P=$(TargetDir)</InterfaceFlags>
+      <FirmwareFlags>-p:RegisterMetadataPath=$(DeviceMetadata) -p:IOMetadataPath=$(IOMetadata) -P=$(TargetDir)</FirmwareFlags>
+    </PropertyGroup>
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(Content.Link)').EndsWith('Device.tt'))"
+          Command="t4 %(Content.Identity) $(InterfaceFlags) -o=$(InterfacePath)\%(Content.Link)" />
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'AppRegs.tt'"
+          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_ios_and_regs.h" />
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'AppFuncs.tt'"
+          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_funcs.h" />
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'App.tt'"
+          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app.h" />
+  </Target>
+</Project>

--- a/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate.sln
+++ b/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("$swguid1$") = "$projectname$", "$projectname$\$projectname$.csproj", "$swguid2$"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		$swguid2$.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		$swguid2$.Debug|Any CPU.Build.0 = Debug|Any CPU
+		$swguid2$.Release|Any CPU.ActiveCfg = Release|Any CPU
+		$swguid2$.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = $swguid3$
+	EndGlobalSection
+EndGlobal

--- a/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
+++ b/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/DeviceTemplate.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>$projectname$</Title>
+    <Authors>$registeredorganization$</Authors>
+    <Copyright>Copyright © $registeredorganization$ $year$</Copyright>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+    <Description>Bonsai Library containing interfaces for data acquisition and control of $title$ devices.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageType>Dependency;BonsaiLibrary</PackageType>
+    <PackageTags>$title$ Bonsai Rx</PackageTags>
+    <PackageProjectUrl></PackageProjectUrl>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageIcon></PackageIcon>
+    <PackageOutputPath></PackageOutputPath>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\device.yml" />
+  </ItemGroup>
+
+</Project>

--- a/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/Properties/AssemblyInfo.cs
+++ b/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:$projectname$", null)]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Daq")]

--- a/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/Properties/launchSettings.json
+++ b/Harp.Templates/Harp.DeviceTemplate/Interface/DeviceTemplate/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir).",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/Harp.Templates/Harp.DeviceTemplate/README.md
+++ b/Harp.Templates/Harp.DeviceTemplate/README.md
@@ -1,0 +1,28 @@
+# $title$
+
+This repository contains the device metadata, firmware and high-level interface to the $devicename$ device. Below are simple getting started instructions for maintainers to create a new device using the automatic code generators.
+
+## Editing device metadata
+
+### Prerequisites
+
+1. Install [Visual Studio Code](https://code.visualstudio.com/)
+2. Install the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).
+
+The `device.yml` file in the root of the project contains the $devicename$ device metadata. A complete specification of all device registers, including bit masks, group masks, and payload formats needs to be provided.
+
+## Generating interface and firmware
+
+### Prerequisites
+
+1. Install [`dotnet`](https://dotnet.microsoft.com/)
+2. Install `dotnet-t4`
+```
+dotnet tool install -g dotnet-t4
+```
+
+The `Generators` folder contains all text templates and project files required to generate both the firmware headers and the interface for the $devicename$ device. To run the text templating engine just build the project inside this folder.
+
+```
+dotnet build Generators
+```

--- a/Harp.Templates/Harp.DeviceTemplate/device.yml
+++ b/Harp.Templates/Harp.DeviceTemplate/device.yml
@@ -1,0 +1,12 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://harp-tech.org/draft-02/schema/device.json
+device: $devicename$
+whoAmI: 0000
+firmwareVersion: "0.1"
+hardwareTargets: "0.0"
+registers:
+  DigitalInputs:
+    address: 32
+    type: U8
+    access: Event

--- a/Harp.Templates/Harp.DeviceTemplate/template.editorconfig
+++ b/Harp.Templates/Harp.DeviceTemplate/template.editorconfig
@@ -1,0 +1,27 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj,bonsai}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs}]
+# Organize usings
+dotnet_sort_system_directives_first = true

--- a/Harp.Templates/Harp.DeviceTemplate/template.gitignore
+++ b/Harp.Templates/Harp.DeviceTemplate/template.gitignore
@@ -1,0 +1,12 @@
+
+desktop.ini
+
+# Visual studio files
+.vs
+.suo
+.nuget
+bin
+obj
+Debug
+packages
+*.componentinfo.xml

--- a/Harp.Templates/Harp.Templates.csproj
+++ b/Harp.Templates/Harp.Templates.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageType>Template</PackageType>
+    <Description>Templates for creating a new Harp device</Description>
+    <PackageTags>Harp Toolkit Device Templates</PackageTags>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Harp.DeviceTemplate\**\*" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+
+</Project>

--- a/Harp.Templates/README.md
+++ b/Harp.Templates/README.md
@@ -1,0 +1,31 @@
+## About
+
+`Harp.Templates` provides templates for creating new [Harp](https://harp-tech.org/) device repositories, including automatic generation of firmware and [Bonsai](https://bonsai-rx.org/) interface code from a device shema.
+
+## How to Use
+
+### Installation
+
+```
+dotnet new install Harp.Templates::0.4.0
+```
+
+### Creating a Device Project
+
+```
+dotnet new harpdevice -n <project-name>
+```
+
+### Run code generation
+
+```
+dotnet build Generators
+```
+
+## Additional Documentation
+
+For additional documentation and examples, refer to [the GitHub repository](https://github.com/harp-tech/toolkit).
+
+## Feedback & Contributing
+
+`Harp.Templates` is released as open-source under the [MIT license](https://licenses.nuget.org/MIT). Bug reports and contributions are welcome at [the GitHub repository](https://github.com/harp-tech/toolkit).

--- a/Harp.Toolkit.sln
+++ b/Harp.Toolkit.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harp.Toolkit", "Harp.Toolkit\Harp.Toolkit.csproj", "{BFC25910-BC44-4792-9CDE-5B3A17D0B157}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Harp.Templates", "Harp.Templates\Harp.Templates.csproj", "{EC58E518-3522-4B04-9A05-DE7F14A51FFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{BFC25910-BC44-4792-9CDE-5B3A17D0B157}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BFC25910-BC44-4792-9CDE-5B3A17D0B157}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BFC25910-BC44-4792-9CDE-5B3A17D0B157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC58E518-3522-4B04-9A05-DE7F14A51FFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC58E518-3522-4B04-9A05-DE7F14A51FFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC58E518-3522-4B04-9A05-DE7F14A51FFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC58E518-3522-4B04-9A05-DE7F14A51FFA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Harp.Toolkit/Harp.Toolkit.csproj
+++ b/Harp.Toolkit/Harp.Toolkit.csproj
@@ -8,7 +8,6 @@
     <PackageTags>Harp Toolkit Device Firmware</PackageTags>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <VersionPrefix>0.1.0</VersionPrefix>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Here we separate out generator releases from the device project template and make it part of the toolkit. This way the toolkit itself can be made part of the template and in general can be made to work well together as a way to manage and update device project repositories.