### PR TITLE
Add default path for device and IO metadata

### DIFF
--- a/src/Harp.Toolkit/Generate/IOMetadataPathOption.cs
+++ b/src/Harp.Toolkit/Generate/IOMetadataPathOption.cs
@@ -9,6 +9,6 @@ public class IOMetadataPathOption : Option<FileInfo>
     {
         OptionValidation.AcceptExistingOnly(this);
         Description = "The path to the file describing the device IO pins.";
-        DefaultValueFactory = _ => new FileInfo("ios.yml");
+        DefaultValueFactory = result => result.AcceptExistingOnly(new FileInfo("ios.yml"));
     }
 }

--- a/src/Harp.Toolkit/Generate/MetadataPathArgument.cs
+++ b/src/Harp.Toolkit/Generate/MetadataPathArgument.cs
@@ -5,10 +5,11 @@ namespace Harp.Toolkit.Generate;
 public class MetadataPathArgument : Argument<FileInfo>
 {
     public MetadataPathArgument()
-        : base("device.yml")
+        : base("metadataPath")
     {
         ArgumentValidation.AcceptExistingOnly(this);
         Description = "The path to the file describing the device registers.";
-        Arity = ArgumentArity.ExactlyOne;
+        DefaultValueFactory = result => result.AcceptExistingOnly(new FileInfo("device.yml"));
+        Arity = ArgumentArity.ZeroOrOne;
     }
 }

--- a/src/Harp.Toolkit/SymbolValidation.cs
+++ b/src/Harp.Toolkit/SymbolValidation.cs
@@ -1,0 +1,13 @@
+﻿using System.CommandLine.Parsing;
+
+namespace Harp.Toolkit;
+
+internal static class SymbolValidation
+{
+    public static FileInfo AcceptExistingOnly(this SymbolResult result, FileInfo fileInfo)
+    {
+        if (!Path.Exists(fileInfo.FullName))
+            result.AddError($"File does not exist: '{fileInfo}'.");
+        return fileInfo;
+    }
+}


### PR DESCRIPTION
Error reporting is handled via the result object to avoid returning long stack traces.